### PR TITLE
Add rocky support

### DIFF
--- a/vars/Rocky.yml
+++ b/vars/Rocky.yml
@@ -1,0 +1,8 @@
+---
+# List of package dependencies.
+os_openstackclient_package_dependencies:
+  - gcc
+  - libffi-devel
+  - openssl-devel
+  - python{{ ansible_facts.python.version.major }}-devel
+  - python{{ ansible_facts.python.version.major }}-pip


### PR DESCRIPTION
Rocky hosts currently fail [here](https://github.com/stackhpc/ansible-role-os-openstackclient/blob/394049840b6481489a5a421ce7dd5cba75594d4e/tasks/main.yml#L3) as their os family is Rocky, not RedHat. 

This could also be resolved by changing the templating to be something like `{{ RedHat if family is Rocky else family }}`, but giving it a different file lets us change things separately if we need to.