### PR TITLE
added vars/Darwin.yml and ensure homebrew doesn't install as root

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
   package:
     name: "{{ os_openstackclient_package_dependencies }}"
     state: present
-  become: True
+  become: "{{ ansible_facts.system != 'Darwin' }}"
   when: os_openstackclient_install_package_dependencies | bool
 
 - block:

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,0 +1,4 @@
+---
+os_openstackclient_package_dependencies:
+  - python3
+  - virtualenv


### PR DESCRIPTION
… root on macos in tasks/main.yml

I just made this role compatible with macos in the same way the ansible-role-os-openstacksdk role already is.